### PR TITLE
Upgrade elasticsearch-py from 7.x to 8.x

### DIFF
--- a/ais/requirements/requirements-dev.txt
+++ b/ais/requirements/requirements-dev.txt
@@ -1,5 +1,5 @@
 beaker>=1.5.0,<2
 black
-elasticsearch>=7.17.1,<8
+elasticsearch>=8,<9
 interrogate==1.5.0
 pre-commit==3.5.0

--- a/ais/src/atlantes/elastic_search/elastic_search_utils.py
+++ b/ais/src/atlantes/elastic_search/elastic_search_utils.py
@@ -72,7 +72,7 @@ def get_es_client(env: str = "integration") -> Any:
     try:
         return Elasticsearch(
             [{"host": ES_HOSTS[env], "port": ES_PORT, "scheme": "https"}],
-            http_auth=(SEARCH_USERNAME, SEARCH_PASSWORD),
+            basic_auth=(SEARCH_USERNAME, SEARCH_PASSWORD),
             request_timeout=30,
             max_retries=2,
             retry_on_timeout=True,

--- a/ais/src/atlantes/eval_scripts/create_distribution_shift_dataset.py
+++ b/ais/src/atlantes/eval_scripts/create_distribution_shift_dataset.py
@@ -73,7 +73,7 @@ def get_subpaths_ids_and_classifications(
         if last_sort_value:
             query["search_after"] = last_sort_value
         es_client = get_es_client()
-        response = es_client.search(index=SUBPATH_INDEX, body=query)
+        response = es_client.search(index=SUBPATH_INDEX, **query)
         response_hits = response["hits"]["hits"]
         if len(response_hits) > 0:
             last_sort_value = response_hits[-1]["sort"]

--- a/ais/src/atlantes/feedback/pull_in_app_feedback_from_es.py
+++ b/ais/src/atlantes/feedback/pull_in_app_feedback_from_es.py
@@ -91,12 +91,10 @@ def get_track_id_from_event_id(event_id: str) -> tuple[str, str, str]:
     """
     try:
         es_client = get_es_client()
-        query = {
-            "query": {"term": {"event_id": {"value": event_id}}},
-            "_source": ["event_id", "vessels.vessel_0.track_id", "start", "end"],
-        }
         response = es_client.search(
-            index=SEARCH_HISTORY_INDEX, body=query
+            index=SEARCH_HISTORY_INDEX,
+            query={"term": {"event_id": {"value": event_id}}},
+            source=["event_id", "vessels.vessel_0.track_id", "start", "end"],
         )
         source_document = response["hits"]["hits"][0]["_source"]
         track_id = source_document["vessels"]["vessel_0"]["track_id"]
@@ -153,8 +151,9 @@ def get_subpath_information_from_trackId_sendtime(
         str: The subpath ID.
     """
     es_client = get_es_client()
-    query = {
-        "query": {
+    response = es_client.search(
+        index=SUBPATH_INDEX,
+        query={
             "bool": {
                 "must": [
                     {"term": {"track_id": track_id}},
@@ -162,9 +161,8 @@ def get_subpath_information_from_trackId_sendtime(
                     {"range": {"end_time": {"lte": event_end_time}}},
                 ]
             }
-        }
-    }
-    response = es_client.search(index=SUBPATH_INDEX, body=query)
+        },
+    )
     if (
         response["hits"]["hits"][0]["_source"]["start_time"]
         < "2024-08-01T09:51:32+00:00"

--- a/ais/src/atlantes/feedback/query_subpath_ids.py
+++ b/ais/src/atlantes/feedback/query_subpath_ids.py
@@ -24,7 +24,7 @@ FISHING_HIGH_SOG_QUERY = {
             ]
         }
     },
-    "_source": ["id"],
+    "source": ["id"],
 }
 
 
@@ -42,7 +42,7 @@ def query_subpath_ids(query: dict) -> pd.DataFrame:
     Query the subpath IDs from the elastic search index
     """
     es_client = get_es_client()
-    response = es_client.search(index=SUBPATH_INDEX, body=query)
+    response = es_client.search(index=SUBPATH_INDEX, **query)
     return pd.DataFrame([hit["_source"]["id"] for hit in response["hits"]["hits"]])
 
 

--- a/ais/src/atlantes/human_annotation/bulk_upload_feedback.py
+++ b/ais/src/atlantes/human_annotation/bulk_upload_feedback.py
@@ -50,7 +50,7 @@ def get_trajectory_project_pairs_all_labeled_fishing() -> list[tuple[str, str]]:
             },
         },
     }
-    res = es_client.search(index=TRACK_ANNOTATION_INDEX, body=query)
+    res = es_client.search(index=TRACK_ANNOTATION_INDEX, **query)
     project_id_trajectory_id_pairs = []
     for record in res["aggregations"]["unique_trajectory_ids"]["buckets"]:
         trajectory_id = record["key"]
@@ -86,7 +86,7 @@ def get_trajectory_project_pairs_all_labeled_fishing() -> list[tuple[str, str]]:
                 },
             },
         }
-        res = es_client.search(index=TRACK_ANNOTATION_INDEX, body=query)
+        res = es_client.search(index=TRACK_ANNOTATION_INDEX, **query)
         if len(res["aggregations"]["unique_trajectory_ids"]["buckets"]) == 0:
             logger.info(f"Trajectory {trajectory_id} has only fishing")
             project_id_trajectory_ids_no_transiting.append((trajectory_id, project_id))
@@ -112,7 +112,7 @@ def get_trajectory_project_pairs_all_labeled_fishing() -> list[tuple[str, str]]:
                 },
             },
         }
-        res2 = es_client.search(index=TRACK_ANNOTATION_INDEX, body=query)
+        res2 = es_client.search(index=TRACK_ANNOTATION_INDEX, **query)
         if len(res2["aggregations"]["unique_trajectory_ids"]["buckets"]) == 0:
             project_id_trajectory_id_pairs_only_fishing.append(
                 (trajectory_id, project_id)
@@ -215,7 +215,7 @@ def get_summary_id_from_project_id_trajectory_id_pair(
             }
         }
     }
-    res = es_client.search(index=TRACK_ANNOTATION_SUMMARY_INDEX, body=query)
+    res = es_client.search(index=TRACK_ANNOTATION_SUMMARY_INDEX, **query)
     logger.info(f"Number of summary ids: {len(res['hits']['hits'])}")
     return res["hits"]["hits"][0]["_id"]
 
@@ -244,7 +244,7 @@ def check_if_project_has_accepted_feedback(id: str) -> bool:
             }
         }
     }
-    res = es_client.search(index=TRACK_ANNOTATION_SUMMARY_INDEX, body=query)
+    res = es_client.search(index=TRACK_ANNOTATION_SUMMARY_INDEX, **query)
     return res["hits"]["hits"][0]["_source"].get("status", None) == accepted_status
 
 

--- a/ais/src/atlantes/human_annotation/get_projects_with_completed_annotations_from_es.py
+++ b/ais/src/atlantes/human_annotation/get_projects_with_completed_annotations_from_es.py
@@ -34,7 +34,7 @@ def get_all_projects() -> list[str]:
         },
     }
     response = PRODUCTION_ES_SEARCH_CLIENT.search(
-        index=TRACK_ANNOTATION_INDEX, body=project_id_agg_query
+        index=TRACK_ANNOTATION_INDEX, **project_id_agg_query
     )
     response = response["aggregations"]["project_counts"]["buckets"]
     return [project["key"] for project in response]
@@ -53,7 +53,7 @@ def get_trajectories_for_project(project_id: str) -> list[str]:
             }
         },
     }
-    res = PRODUCTION_ES_SEARCH_CLIENT.search(index=TRACK_ANNOTATION_INDEX, body=query)
+    res = PRODUCTION_ES_SEARCH_CLIENT.search(index=TRACK_ANNOTATION_INDEX, **query)
     trajectories = [
         b["key"] for b in res["aggregations"]["unique_trajectory_ids"]["buckets"]
     ]
@@ -76,7 +76,7 @@ def is_trajectory_completed(project_id: str, trajectory_id: str) -> bool:
             }
         }
     }
-    res = PRODUCTION_ES_SEARCH_CLIENT.search(index=TRACK_ANNOTATION_INDEX, body=query)
+    res = PRODUCTION_ES_SEARCH_CLIENT.search(index=TRACK_ANNOTATION_INDEX, **query)
     return res["hits"]["total"]["value"] == 0
 
 
@@ -98,7 +98,7 @@ def get_num_trajectories_with_fishing_annotation() -> int:
         },
     }
 
-    res = PRODUCTION_ES_SEARCH_CLIENT.search(index=TRACK_ANNOTATION_INDEX, body=query)
+    res = PRODUCTION_ES_SEARCH_CLIENT.search(index=TRACK_ANNOTATION_INDEX, **query)
     return len(res["aggregations"]["unique_trajectory_ids"]["buckets"])
 
 
@@ -161,7 +161,7 @@ def how_many_tracks_are_completely_annotated() -> Tuple[list[str], list[str]]:
         },
     }
     response = PRODUCTION_ES_SEARCH_CLIENT.search(
-        index=TRACK_ANNOTATION_INDEX, body=project_id_agg_query
+        index=TRACK_ANNOTATION_INDEX, **project_id_agg_query
     )
     response = response["aggregations"]["all_trajectory_ids"]["buckets"]
     logger.info(f"Number of tracks: {len(response)}")
@@ -184,7 +184,7 @@ def how_many_tracks_are_completely_annotated() -> Tuple[list[str], list[str]]:
 
         response = PRODUCTION_ES_SEARCH_CLIENT.search(
             index=TRACK_ANNOTATION_INDEX,
-            body=are_any_points_in_trajectory_unannotated_query,
+            **are_any_points_in_trajectory_unannotated_query,
             size=1,
         )
         if response["hits"]["total"]["value"] > 0:
@@ -204,7 +204,7 @@ def how_many_annotated_points() -> int:
         "aggs": {"annotated_points": {"filter": {"exists": {"field": "annotated"}}}},
     }
     response = PRODUCTION_ES_SEARCH_CLIENT.search(
-        index=TRACK_ANNOTATION_INDEX, body=annotated_points_query
+        index=TRACK_ANNOTATION_INDEX, **annotated_points_query
     )
     response = response["aggregations"]["annotated_points"]["doc_count"]
     logger.info(f"Number of annotated points: {response}")
@@ -227,7 +227,7 @@ def get_all_projects_completely_labeled_as_fishing() -> list:
             },
         },
     }
-    res = PRODUCTION_ES_SEARCH_CLIENT.search(index=TRACK_ANNOTATION_INDEX, body=query)
+    res = PRODUCTION_ES_SEARCH_CLIENT.search(index=TRACK_ANNOTATION_INDEX, **query)
     all_fishing_tracks = [
         b["key"] for b in res["aggregations"]["unique_trajectory_ids"]["buckets"]
     ]
@@ -253,7 +253,7 @@ def get_all_projects_completely_labeled_as_fishing() -> list:
             },
         }
         res = PRODUCTION_ES_SEARCH_CLIENT.search(
-            index=TRACK_ANNOTATION_INDEX, body=query
+            index=TRACK_ANNOTATION_INDEX, **query
         )
         if len(res["aggregations"]["unique_trajectory_ids"]["buckets"]) == 0:
             only_fishing_tracks.append(trajectory_id)

--- a/ais/src/atlantes/human_annotation/human_annotation_utils.py
+++ b/ais/src/atlantes/human_annotation/human_annotation_utils.py
@@ -124,7 +124,7 @@ def get_all_trajectory_infos_in_annotation_tool(
     }
 
     # Execute the query
-    response = es_client.search(index=TRACK_ANNOTATION_INDEX, body=query)
+    response = es_client.search(index=TRACK_ANNOTATION_INDEX, **query)
 
     # Trajectory Ids are the names of the files that contain the trajectories We also want to likely keep the track_id otherwise we should just query them directly
     trajectory_ids = [
@@ -147,7 +147,7 @@ def get_all_trajectory_infos_in_annotation_tool(
             },
         }
         response = es_client.search(
-            index=TRACK_ANNOTATION_INDEX, body=get_track_id_send_timestamp_query
+            index=TRACK_ANNOTATION_INDEX, **get_track_id_send_timestamp_query
         )
         doc = response["hits"]["hits"][0]
         track_id = doc["_source"]["track_id"]
@@ -513,7 +513,7 @@ def get_trajectory_id_project_id_pairs() -> list[tuple[str, str]]:
             }
         },
     }
-    res = es_client.search(index=TRACK_ANNOTATION_INDEX, body=query)
+    res = es_client.search(index=TRACK_ANNOTATION_INDEX, **query)
     project_id_trajectory_id_pairs = []
     for record in res["aggregations"]["unique_trajectory_ids"]["buckets"]:
         trajectory_id = record["key"]
@@ -540,7 +540,7 @@ def check_if_project_has_given_feedback_status(id: str, feedback_status: str) ->
         }
     }
     es_client = get_es_client("production")
-    res = es_client.search(index=TRACK_ANNOTATION_SUMMARY_INDEX, body=query)
+    res = es_client.search(index=TRACK_ANNOTATION_SUMMARY_INDEX, **query)
     status = res["hits"]["hits"][0]["_source"].get("status", None)
     logger.info(f"Status of project {id} is {status}")
     return status == feedback_status
@@ -561,7 +561,7 @@ def get_summary_id_from_project_id_trajectory_id_pair(
             }
         }
     }
-    res = es_client.search(index=TRACK_ANNOTATION_SUMMARY_INDEX, body=query)
+    res = es_client.search(index=TRACK_ANNOTATION_SUMMARY_INDEX, **query)
     return res["hits"]["hits"][0]["_id"]
 
 


### PR DESCRIPTION
## Summary

- Upgrades `elasticsearch` dependency from `>=7.17.1,<8` to `>=8,<9` in `ais/requirements/requirements-dev.txt`
- Changes `http_auth` to `basic_auth` in the Elasticsearch client constructor (`elastic_search_utils.py`)
- Replaces all deprecated `body=` parameter usage with `**kwargs` unpacking in `search()` calls across 6 files
- Renames `_source` query dict key to `source` for ES 8.x Python client API compatibility

## Motivation

Part of the coordinated elasticsearch 8.x upgrade across all Skylight services. See https://github.com/VulcanSkylight/skylight-planning/pull/28 for the planning PR.

## Risk Assessment

**Risk score: 4 (Low)**

- This is a **dev-only** dependency (`requirements-dev.txt`), not used in production service deployments
- The elasticsearch client in atlantes is used for annotation tooling, feedback processing, and evaluation scripts -- not in the real-time inference pipeline
- Changes are mechanical: `http_auth` -> `basic_auth`, `body=query` -> `**query`, `_source` -> `source`
- Verified that `elasticsearch` 8.19.3 installs and the `basic_auth` parameter is accepted

## Test plan

- [x] Verified `elasticsearch` 8.x installs successfully
- [x] Verified `basic_auth` parameter works with ES 8.x client constructor
- [x] Verified `search()` method accepts `query`, `aggs`, `size`, `sort`, `source`, `search_after` as top-level kwargs
- [ ] Manual testing against integration ES cluster to confirm queries work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)