### PR TITLE
Add bare trailing-voltage pattern for buoy/gear name detection

### DIFF
--- a/ais/src/atlantes/machine_annotation/data_annotate_utils.py
+++ b/ais/src/atlantes/machine_annotation/data_annotate_utils.py
@@ -101,6 +101,11 @@ ENGLISH_SPEAKING_MMSIS_CODES = [
 #     reporting convention in gear names (~18% of GEAR records in VHS). The decimal
 #     voltage format (e.g. [7.7V]) adds ~1,355 incremental catches at 45% GEAR
 #     and only 1% FISHING.
+#   - Bare trailing voltage: "\d\s+\d+V\b" (e.g. "368000010   9V"). Whole-number
+#     volts ("9V", "12V") reported as a separate token after an ID/digit block,
+#     with no trailing decimal digit (so not caught by "\d+V\d+"). The leading
+#     "\d\s+" anchor requires preceding numeric content, which keeps the standalone
+#     "6V"/"7V" garbled-AIS case excluded (see NOT-included note below).
 #   - Double-dash separators: "\d+--\d+" (04001--2, 17002--41).
 #     Gear IDs frequently use double-dashes between numeric fields. Validated
 #     against VHS: 1,135 names not already caught by other patterns, of which
@@ -128,6 +133,7 @@ NAME_PATTERNS_FOR_BUOYS = [
     r"\d+%",
     r"\d+V\d+",
     r"\d+\.\d+V",
+    r"\d\s+\d+V\b",
     r"\d+--\d+",
     r"Net fish",
     r"NetFish",

--- a/ais/tests/unit/inference/atlas_entity/test_unit_entity_postprocessor.py
+++ b/ais/tests/unit/inference/atlas_entity/test_unit_entity_postprocessor.py
@@ -716,6 +716,41 @@ class TestAtlasEntityPostProcessor:
         assert output.entity_class == "buoy"
         assert output.entity_classification_details.postprocess_rule_applied is True
 
+    @pytest.mark.parametrize(
+        "entity_name",
+        [
+            "368000010         9V",
+            "368000002         9V",
+            "BUOY 992-536     12V",
+        ],
+    )
+    def test_postprocess_bare_trailing_voltage_classified_as_buoy(
+        self,
+        entity_name: str,
+        entity_postprocessor_class: AtlasEntityPostProcessor,
+    ) -> None:
+        """Test that names with a bare trailing voltage token (e.g. "9V", no decimal
+        digit) following a digit block are classified as buoys, even for USA MMSIs."""
+        input_data = EntityPostprocessorInput(
+            predicted_class=AtlasEntityLabelsTrainingWithUnknown.VESSEL,
+            entity_classification_details=EntityPostprocessorInputDetails(
+                model="test", confidence=0.9, outputs=[0.9, 0.1]
+            ),
+            metadata=EntityMetadata(
+                binned_ship_type=0,
+                ais_type=9999,
+                mmsi="368000010",
+                entity_name=entity_name,
+                track_length=800,
+                file_location=None,
+                trackId="A:368000010",
+                flag_code="USA",
+            ),
+        )
+        output = entity_postprocessor_class.postprocess(input_data)
+        assert output.entity_class == "buoy"
+        assert output.entity_classification_details.postprocess_rule_applied is True
+
     def test_postprocess_raises_error_for_known_binned_ship_type_and_buoy_name(
         self, entity_postprocessor_class: AtlasEntityPostProcessor
     ) -> None:


### PR DESCRIPTION
## Motivation

Paige reported AIS entities with obvious buoy/gear names being mis-classified as `vessel` — e.g. `"368000010         9V"` (MMSI + whole-number battery voltage). These slipped through the name-based buoy detection because the existing voltage pattern `\d+V\d+` requires a trailing decimal digit (matches `8V2` = 8.2V), so a bare `9V`/`12V` reading never matched any pattern in `NAME_PATTERNS_FOR_BUOYS`.

## Changes

Add `\d\s+\d+V\b` to `NAME_PATTERNS_FOR_BUOYS`. The leading `\d\s+` anchor requires a preceding digit block (the ID/MMSI), which keeps the deliberately-excluded standalone `"6V"`/`"7V"` garbled-AIS case out — only voltage tokens trailing real name content are caught. Adds a parametrized test using both reported names plus a USA (`368…`) MMSI to confirm the regex branch fires regardless of flag.

## Reviewer Attention

- `data_annotate_utils.py` — the new pattern is OR'd into the case-insensitive `NAME_PATTERNS_FOR_BUOYS` regex; worth confirming `\d\s+\d+V\b` doesn't over-match legitimate vessel names with a `"<num> <num>V"` token. Standalone-`9V` exclusion and common vessel names verified clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)