### PR TITLE
Fix broken marine-infrastructure geojson URL in image build

### DIFF
--- a/ais/Dockerfile
+++ b/ais/Dockerfile
@@ -52,7 +52,7 @@ COPY ./ /ais
 # Download the external marine infrastructure file and install package
 RUN mkdir -p /ais/src/atlantes/data && \
     wget -O /ais/src/atlantes/data/latest_marine_infrastructure.geojson \
-        https://pub-956f3eb0f5974f37b9228e0a62f449bf.r2.dev/outputs/marine/latest.geojson \
+        https://storage.googleapis.com/satlas-explorer-public/outputs/marine/latest.geojson \
         --quiet && \
     python -m pip install --no-cache-dir .
 


### PR DESCRIPTION
## Motivation

Every Docker build in this repo (`tests` and `build-and-push-image`) currently fails at `ais/Dockerfile:53`, where the entity image downloads `latest_marine_infrastructure.geojson` at build time. The R2-hosted source now returns `401 Unauthorized` — the bucket's public access was revoked sometime after the last green build on `main` (2026-03-24), so the failure surfaces on the first build attempt since. It is unrelated to any code change.

## Changes

Point the build-time `wget` at the GCS-hosted copy of the same file (`https://storage.googleapis.com/satlas-explorer-public/outputs/marine/latest.geojson`), which serves it with public read access (verified `200`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)