### PR TITLE
Anchor net buoy-name patterns with \b to stop matching real vessels

### DIFF
--- a/ais/src/atlantes/machine_annotation/data_annotate_utils.py
+++ b/ais/src/atlantes/machine_annotation/data_annotate_utils.py
@@ -88,7 +88,11 @@ ENGLISH_SPEAKING_MMSIS_CODES = [
 # Common ways of naming a buoy on AIS generalized from anecdotal observations.
 #
 # These patterns are matched case-insensitively against entity names. They cover:
-#   - Net identifiers: "net\d+" (NET10), "net\s+\w+" (NET 1, NET D)
+#   - Net identifiers: "\bnet\d+" (NET10), "\bnet\s+\w+" (NET 1, NET D).
+#     The leading "\b" requires "net" to start a word, so mid-word matches in real
+#     vessel names (SIGNET, GANNET, PLANET, GARNET, MADINET, JEANET...) are NOT
+#     treated as buoys. The same "\b" anchor is applied to the explicit gear names
+#     below for the same reason.
 #   - Chinese fishing gear suffixes: "yu\s*\d+-\d+" (MINPINGYU63036-1, ZHE DAI YU 04455-44).
 #     Chinese fishing vessels use province+"YU"+registration (e.g. MINPINGYU63036).
 #     A -N suffix indicates individual nets/gear, not the vessel itself.
@@ -110,7 +114,7 @@ ENGLISH_SPEAKING_MMSIS_CODES = [
 #     Gear IDs frequently use double-dashes between numeric fields. Validated
 #     against VHS: 1,135 names not already caught by other patterns, of which
 #     50.5% are GFW GEAR and only 3% FISHING.
-#   - Explicit gear names: "fishing gear", "Net fish", "NetFish", "NET MARK"
+#   - Explicit gear names: "fishing gear", "\bNet fish", "\bNetFish", "\bNET MARK"
 #   - Numeric gear IDs: "\d{3,5} \d+ \d+" (e.g. "02333 287 82", "1638 48 90",
 #     "78000 35 99"). Three-to-five-digit ID followed by space-separated numeric
 #     fields (likely channel/signal and battery level without %). Observed in large
@@ -126,8 +130,8 @@ ENGLISH_SPEAKING_MMSIS_CODES = [
 #   - Bracket voltage ("[8.0V]", "[7.1V]"): very rare in VHS data. Could revisit
 #     if more examples surface.
 NAME_PATTERNS_FOR_BUOYS = [
-    r"net\d+",
-    r"net\s+\w+",
+    r"\bnet\d+",
+    r"\bnet\s+\w+",
     r"yu\s*\d+-\d+",
     r"fishing gear",
     r"\d+%",
@@ -135,9 +139,9 @@ NAME_PATTERNS_FOR_BUOYS = [
     r"\d+\.\d+V",
     r"\d\s+\d+V\b",
     r"\d+--\d+",
-    r"Net fish",
-    r"NetFish",
-    r"NET MARK",
+    r"\bNet fish",
+    r"\bNetFish",
+    r"\bNET MARK",
     r"\d{3,5} \d+ \d+",
 ]
 

--- a/ais/tests/unit/inference/atlas_entity/test_unit_entity_postprocessor.py
+++ b/ais/tests/unit/inference/atlas_entity/test_unit_entity_postprocessor.py
@@ -534,6 +534,43 @@ class TestAtlasEntityPostProcessor:
     @pytest.mark.parametrize(
         "entity_name",
         [
+            "SIGNET ARCTURUS",
+            "GANNET S",
+            "PLANET OCEAN",
+            "GARNET STAR",
+            "MADINET BENI-SAF",
+            "JEANET MAARTJE",
+        ],
+    )
+    def test_postprocess_midword_net_not_classified_as_buoy(
+        self,
+        entity_name: str,
+        entity_postprocessor_class: AtlasEntityPostProcessor,
+    ) -> None:
+        """Real vessels with 'net' mid-word must not match the net buoy patterns."""
+        input_data = EntityPostprocessorInput(
+            predicted_class=AtlasEntityLabelsTrainingWithUnknown.VESSEL,
+            entity_classification_details=EntityPostprocessorInputDetails(
+                model="test", confidence=0.9, outputs=[0.9, 0.1]
+            ),
+            metadata=EntityMetadata(
+                binned_ship_type=0,
+                ais_type=9999,
+                mmsi="123456789",
+                entity_name=entity_name,
+                track_length=800,
+                file_location=None,
+                trackId="A:123456789",
+                flag_code="USA",
+            ),
+        )
+        output = entity_postprocessor_class.postprocess(input_data)
+        assert output.entity_class == "vessel"
+        assert output.entity_classification_details.postprocess_rule_applied is False
+
+    @pytest.mark.parametrize(
+        "entity_name",
+        [
             "MINPINGYU63036-1",
             "MINDONGYU62646-5",
             "LURONGYU60365-2",


### PR DESCRIPTION
## Motivation

The `net`-prefixed entries in `NAME_PATTERNS_FOR_BUOYS` had no leading word boundary, so the substring `net` matched **mid-word** in real vessel names and the postprocessor flipped them to `buoy`. Found while sweeping integration for mislabeled buoys: `net\s+\w+` matched real vessels like `SIGNET ARCTURUS`, `GANNET S`, `PLANET OCEAN`, `GARNET STAR`, `MADINET BENI-SAF`, `JEANET MAARTJE` (the `SIGNET` fleet are real tugs). ~1,400 such false positives showed up in one integration slice alone.

## Changes

Anchor every `net`-starting pattern with `\b` (`\bnet\d+`, `\bnet\s+\w+`, `\bNet fish`, `\bNetFish`, `\bNET MARK`) so `net` must begin a word. Genuine buoy names (`NET 1`, `NET10`, `NETFISH...`, `NET MARK`) are unaffected — `net` already starts a word there, so existing net tests still pass. Adds a regression test asserting the six real-vessel names above stay `vessel`.

## Reviewer Attention

- `data_annotate_utils.py` — this is a **precision tightening** of a live postprocessor rule: names where `net` appears mid-word will no longer be classified buoy. Intended. Slight recall trade-off for genuine buoys whose name embeds `net` mid-word (e.g. a hypothetical `FISHNET 5`), which seems acceptable against the real-vessel false positives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)