### PR TITLE
Allow Fishing ship type with buoyish name as a buoy

### DIFF
--- a/ais/src/atlantes/inference/atlas_entity/postprocessor.py
+++ b/ais/src/atlantes/inference/atlas_entity/postprocessor.py
@@ -74,6 +74,11 @@ class AtlasEntityPostProcessor:
             "Not enough messages",
         )
 
+        self.fishing_buoy_name_allowed_rule_applied = Counter(
+            "entity_post_processed_fishing_buoy_name_allowed",
+            "Buoyish name with a Fishing ship type allowed through as a buoy",
+        )
+
     def is_binned_ship_type_known(self, binned_ship_type: int) -> bool:
         """Check if the ship type is known"""
         if binned_ship_type not in self.ais_categories["category"].values:
@@ -85,6 +90,20 @@ class AtlasEntityPostProcessor:
             ].iloc[0]
         )
         return binned_ship_type != unknown_category
+
+    def is_binned_ship_type_fishing(self, binned_ship_type: int) -> bool:
+        """Check if the binned ship type is Fishing.
+
+        A lot of fishing gear (buoys, nets, FADs) reports a Fishing ship type, so a
+        buoyish name paired with a Fishing ship type is expected rather than a conflict."""
+        if binned_ship_type not in self.ais_categories["category"].values:
+            raise ValueError(f"Unknown ship type {binned_ship_type=}")
+        fishing_category = int(
+            self.ais_categories[self.ais_categories["category_desc"] == "Fishing"][
+                "category"
+            ].iloc[0]
+        )
+        return binned_ship_type == fishing_category
 
     def check_confidence_threshold(
         self, confidence: float, predicted_class: AtlasEntityLabelsTrainingWithUnknown
@@ -126,19 +145,26 @@ class AtlasEntityPostProcessor:
             )
             binned_ship_type = int(metadata.binned_ship_type)
         is_buoy_name = is_buoy_based_on_name(metadata.mmsi, metadata.entity_name)
-        # TODO: Ask SME if Fishing reporting vessels can be buoys
         is_known_binned_ship_type = self.is_binned_ship_type_known(binned_ship_type)
+        # A lot of fishing gear reports a Fishing ship type, so a buoyish name with a
+        # Fishing ship type is allowed through and classified as a buoy rather than raising.
+        is_fishing_binned_ship_type = self.is_binned_ship_type_fishing(binned_ship_type)
         has_not_enough_messages = (
             metadata.track_length < self.data_config["MIN_AIS_MESSAGES"]
         )
 
         # Postprocessing Rules
-        if is_buoy_name and is_known_binned_ship_type:
+        if is_buoy_name and is_known_binned_ship_type and not is_fishing_binned_ship_type:
             logger.error(
                 f"known ship type and buoyish name {binned_ship_type=}, {metadata.entity_name=}"
             )
             raise KnownShipTypeAndBuoyName()
         elif was_post_processed := is_buoy_name:
+            if is_fishing_binned_ship_type and is_known_binned_ship_type:
+                logger.info(
+                    f"Fishing ship type with buoyish name allowed through as buoy {metadata.entity_name=}"
+                )
+                self.fishing_buoy_name_allowed_rule_applied.inc()
             logger.info(f"Buoyish name {metadata.entity_name=}")
             self.buoy_post_processed_rule_applied.inc()
             postprocessed_entity_class = AtlasEntityLabelsTrainingWithUnknown.BUOY

--- a/ais/tests/unit/inference/atlas_entity/test_unit_entity_postprocessor.py
+++ b/ais/tests/unit/inference/atlas_entity/test_unit_entity_postprocessor.py
@@ -812,3 +812,68 @@ class TestAtlasEntityPostProcessor:
             entity_postprocessor_class.postprocess(
                 entity_outputs_with_details_metadata_tuples_1
             )
+
+    def test_is_binned_ship_type_fishing(
+        self, entity_postprocessor_class: AtlasEntityPostProcessor
+    ) -> None:
+        """The Fishing category (2) is fishing; other known categories are not."""
+        assert entity_postprocessor_class.is_binned_ship_type_fishing(2)
+        assert not entity_postprocessor_class.is_binned_ship_type_fishing(8)
+
+    def test_postprocess_fishing_ship_type_and_buoy_name_allowed_as_buoy(
+        self, entity_postprocessor_class: AtlasEntityPostProcessor
+    ) -> None:
+        """A Fishing ship type with a buoyish name is allowed through as a buoy.
+
+        A lot of fishing gear reports a Fishing ship type, so this pairing must not
+        raise KnownShipTypeAndBuoyName the way other known ship types do."""
+        fishing_binned_ship_type = 2
+        entity_outputs_with_details_metadata_tuples_1 = EntityPostprocessorInput(
+            predicted_class=AtlasEntityLabelsTrainingWithUnknown.VESSEL,
+            entity_classification_details=EntityPostprocessorInputDetails(
+                model="test", confidence=0.9, outputs=[0.9, 0.1]
+            ),
+            metadata=EntityMetadata(
+                binned_ship_type=fishing_binned_ship_type,
+                mmsi="123456789",
+                entity_name="Net-18%",
+                track_length=800,
+                file_location=None,
+                trackId="B:123456789",
+                flag_code="USA",
+                ais_type=30,
+            ),
+        )
+        output = entity_postprocessor_class.postprocess(
+            entity_outputs_with_details_metadata_tuples_1
+        )
+        assert output.entity_class == "buoy"
+        assert output.entity_classification_details.postprocess_rule_applied is True
+
+    def test_postprocess_fishing_ais_type_and_buoy_name_allowed_as_buoy(
+        self, entity_postprocessor_class: AtlasEntityPostProcessor
+    ) -> None:
+        """The Fishing exception also applies when the type is binned from ais_type=30.
+
+        Mirrors the production case (WIN 6+, ais_type 30) that previously raised."""
+        entity_outputs_with_details_metadata_tuples_1 = EntityPostprocessorInput(
+            predicted_class=AtlasEntityLabelsTrainingWithUnknown.VESSEL,
+            entity_classification_details=EntityPostprocessorInputDetails(
+                model="test", confidence=0.9, outputs=[0.9, 0.1]
+            ),
+            metadata=EntityMetadata(
+                binned_ship_type=None,
+                mmsi="674118012",
+                entity_name="Net-18%",
+                track_length=800,
+                file_location=None,
+                trackId="B:674118012",
+                flag_code="USA",
+                ais_type=30,
+            ),
+        )
+        output = entity_postprocessor_class.postprocess(
+            entity_outputs_with_details_metadata_tuples_1
+        )
+        assert output.entity_class == "buoy"
+        assert output.entity_classification_details.postprocess_rule_applied is True


### PR DESCRIPTION
Relates to VulcanSkylight/skylight-planning#272

## Motivation

The entity postprocessor raised `KnownShipTypeAndBuoyName` (an `INVALID_ARGUMENT` gRPC error) whenever a track had a *known* AIS ship type **and** a buoyish name. But a lot of fishing gear — buoys, nets, FADs — legitimately reports a **Fishing** ship type (`ais_type` 30 / category 2) with a buoyish name. These valid cases were treated as data conflicts, flooding logs with errors like `WIN 6+ (ais_type 30) ... returned INVALID_ARGUMENT`. The SMEs decided Fishing-typed tracks with buoyish names should be allowed through and classified as buoys.

## Changes

- Add `is_binned_ship_type_fishing()` and exempt the Fishing category from the known-ship-type + buoy-name guard, so those tracks fall through to the existing buoy classification rule instead of raising.
- Other known ship types still raise `KnownShipTypeAndBuoyName` as before.
- Add `entity_post_processed_fishing_buoy_name_allowed` counter for observability.
- Unit tests for the helper and both the binned-type and `ais_type=30` paths.

## Reviewer Attention

- `postprocessor.py:157` — the guard now requires `and not is_fishing_binned_ship_type`; confirm the carve-out is scoped to Fishing only and non-fishing known types still raise.